### PR TITLE
Implemented WildCards support and Added Check command in update

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Downloads the specified universal package and extracts its contents to a directo
     upack install «package» [«version»] --source=«source» --target=«target» [--user=«authentication»] [--comment=«comment»] [--overwrite] [--prerelease] [--userregistry] [--unregistered] [--cache]
 
  - **`package`** - Package name and group, such as group/name.
- - `version` - Package version. If not specified, the latest version is retrieved.
+ - `version` - Package version. Supports wildcards (*). If not specified, the latest version is retrieved.
  - `source` - URL of a upack API endpoint. If not specified, the `UPACK_FEED` environment variable is used.
  - `target` - Directory where the contents of the package will be extracted.
  - `user` - Credentials to use for servers that require authentication. This can be either `«username»:«password»` or `api:«api-key»`. If not specified, the `UPACK_USER` environment variable is used.
@@ -91,7 +91,7 @@ Update the specified universal package.
     upack update «package» [«version»] --source=«source» --target=«target» [--user=«authentication»] [--comment=«comment»] [--prerelease] [--userregistry] [--unregistered] [--cache] [--force]
 
  - **`package`** - Package name and group, such as group/name.
- - `version` - Package version. If not specified, the latest version is retrieved.
+ - `version` - Package version. Supports wildcards (*). If not specified, the latest version is retrieved.
  - `source` - URL of a upack API endpoint. If not specified, the URL in registry or `UPACK_FEED` environment variable is used.
  - `target` - (Optional) Directory where the package is installed.
  - `user` - Credentials to use for servers that require authentication. This can be either `«username»:«password»` or `api:«api-key»`. If not specified, the `UPACK_USER` environment variable is used.
@@ -122,7 +122,7 @@ Downloads a universal package from a feed without installing it.
     upack get «package» [«version»] --source=«source» --target=«target» [--user=«authentication»] [--overwrite] [--prerelease]
 
  - **`package`** - Package name and group, such as group/name.
- - `version` - Package version. If not specified, the latest version is retrieved.
+ - `version` - Package version. Supports wildcards (*). If not specified, the latest version is retrieved.
  - `source` - URL of a upack API endpoint. If not specified, the `UPACK_FEED` environment variable is used.
  - `target` - Directory where the contents of the package will be extracted.
  - `user` - Credentials to use for servers that require authentication. This can be either `«username»:«password»` or `api:«api-key»`. If not specified, the `UPACK_USER` environment variable is used.
@@ -174,7 +174,7 @@ Displays metadata for a remote universal package.
     upack metadata «package» [«version»] --source=«source» [--user=«authentication»] [--file=«file»]
 
  - **`package`** - Package name and group, such as group/name.
- - `version` - Package version. If not specified, the latest version is retrieved.
+ - `version` - Package version. Supports wildcards (*). If not specified, the latest version is retrieved.
  - **`source`** - URL of a upack API endpoint. If not specified, the `UPACK_FEED` environment variable is used.
  - `user` - Credentials to use for servers that require authentication. This can be either `«username»:«password»` or `api:«api-key»`. If not specified, the `UPACK_USER` environment variable is used.
  - `file` - The metadata file to display relative to the .upack root; the default is upack.json.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Downloads the specified universal package and extracts its contents to a directo
 
 Update the specified universal package.
 
-    upack update «package» [«version»] --source=«source» --target=«target» [--user=«authentication»] [--comment=«comment»] [--prerelease] [--userregistry] [--unregistered] [--cache] [--force]
+    upack update «package» [«version»] --source=«source» --target=«target» [--user=«authentication»] [--comment=«comment»] [--prerelease] [--userregistry] [--unregistered] [--cache] [--force] [--check]
 
  - **`package`** - Package name and group, such as group/name.
  - `version` - Package version. Supports wildcards (*). If not specified, the latest version is retrieved.
@@ -102,6 +102,7 @@ Update the specified universal package.
  - `cache` - Cache the contents of the package in the local registry.
  - `clean` - Delete the directory of the package to perform a clean update.
  - `force` - Force the update even if it's already up-to-date.
+ - `check` - Checks for new package update.
 
 ### remove
 

--- a/src/upack/Command.cs
+++ b/src/upack/Command.cs
@@ -351,7 +351,50 @@ namespace Inedo.UPack.CLI
 
         internal static async Task<UniversalPackageVersion> GetVersionAsync(UniversalFeedClient client, UniversalPackageId id, string version, bool prerelease, CancellationToken cancellationToken)
         {
-            if (!string.IsNullOrEmpty(version) && !string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase) && !prerelease)
+            IReadOnlyList<RemoteUniversalPackageVersion> versions;
+
+            if (!string.IsNullOrEmpty(version) && version.Contains('*'))
+            {
+                versions = await ListVersions();
+
+                string[] splitedVersion = version.Split(".");
+
+                if(splitedVersion.Length > 3 )
+                    throw new UpackException($"Invalid UPack version number: {version}");
+
+                int[] versionPartsMax = new[] { int.MaxValue, int.MaxValue, int.MaxValue };
+                int[] versionPartsMin = new[] { 0, 0, 0};
+                
+                try
+                {
+                    for (int i = 0; i < splitedVersion.Length; i++)
+                    {
+                        if (splitedVersion[i] != "*")
+                        {
+                            versionPartsMax[i] = int.Parse(splitedVersion[i]);
+                            versionPartsMin[i] = int.Parse(splitedVersion[i]);
+                        }
+                    }
+                }
+                catch (Exception)
+                {
+                    throw new UpackException($"Invalid UPack version number: {version}");
+                }
+            
+
+                UniversalPackageVersion maxWildVersion = new(versionPartsMax[0], versionPartsMax[1], versionPartsMax[2]);
+                UniversalPackageVersion minWildVersion = new(versionPartsMin[0], versionPartsMin[1], versionPartsMin[2]);
+
+                var wildVersions = versions.Where(v => v.Version <= maxWildVersion 
+                                                    && v.Version >= minWildVersion)
+                                                    .ToArray();
+
+                if (!wildVersions.Any())
+                    throw new UpackException($"Version not found {version}");
+
+                return wildVersions.Max(v => v.Version);
+            }
+            else if (!string.IsNullOrEmpty(version) && !string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase) && !prerelease)
             {
                 var parsed = UniversalPackageVersion.TryParse(version);
                 if (parsed != null)
@@ -360,24 +403,29 @@ namespace Inedo.UPack.CLI
                 throw new UpackException($"Invalid UPack version number: {version}");
             }
 
-            IReadOnlyList<RemoteUniversalPackageVersion> versions;
-            try
-            {
-                versions = await client.ListPackageVersionsAsync(id, false, null, cancellationToken);
-            }
-            catch (WebException ex)
-            {
-                throw ConvertWebException(ex);
-            }
-
-            if (!versions.Any())
-                throw new UpackException($"No versions of package {id} found.");
+            versions = await ListVersions();
 
             var matchingVersions = versions.Where(v => v.Version.Prerelease != null == prerelease).ToArray();
             if (!matchingVersions.Any())
                 throw new UpackException($"No {(prerelease ? "pre" : "")}release versions of package {id} found.");
             return matchingVersions.Max(v => v.Version);
-        }
+
+            async Task<IReadOnlyList<RemoteUniversalPackageVersion>> ListVersions()
+            {
+                try
+                {
+                    versions = await client.ListPackageVersionsAsync(id, false, null, cancellationToken);
+                    if (!versions.Any())
+                        throw new UpackException($"No versions of package {id} found.");
+
+                    return versions;
+                }
+                catch (WebException ex)
+                {
+                    throw ConvertWebException(ex);
+                }
+            }
+        }        
 
         internal const string PackageNotFoundMessage = "The specified universal package was not found at the given URL";
         internal const string FeedNotFoundMessage = "No UPack feed was found at the given URL";

--- a/src/upack/Command.cs
+++ b/src/upack/Command.cs
@@ -385,9 +385,9 @@ namespace Inedo.UPack.CLI
                 UniversalPackageVersion maxWildVersion = new(versionPartsMax[0], versionPartsMax[1], versionPartsMax[2]);
                 UniversalPackageVersion minWildVersion = new(versionPartsMin[0], versionPartsMin[1], versionPartsMin[2]);
 
-                var wildVersions = versions.Where(v => v.Version <= maxWildVersion 
-                                                    && v.Version >= minWildVersion)
-                                                    .ToArray();
+                var wildVersions = versions.Where(v => v.Version <= maxWildVersion && v.Version >= minWildVersion)
+                                                .Where(v => v.Version.Prerelease != null == prerelease)
+                                                .ToArray();
 
                 if (!wildVersions.Any())
                     throw new UpackException($"Version not found {version}");


### PR DESCRIPTION
I implemented wildcards to solve the issue #63 

Example:
`upack packageName install 1.*`
`upack packageName update 2.3.*`
 
And I added the command --check in the update, if you just want to check updates using some automation software it will be helpful.

Using wildcards and check command you can do some tricks, like:
Exemple: If you have a package with two main versions like 1.x and 2.x, and the 1.x is still getting updates and you don't intend to update it to 2.x yet, you can check for updates only on 1.x  
`upack packageName update 1.* --check`

And update only for 1.x with:  
`upack packageName update 1.*`

Since the wildcard is implemented in the GetVersionAsync method, basically all commands that allow inserting the version can now use wildcards.

In my last commit, I changed the wildcard behavior to follow the project logic, where all version checks only return releases unless using the --prerelease command, and using this command it only returns prereleases.

`upack packageName update 1.* --prerelease`  
`upack packageName update 1.* --check --prerelease`  
Will update or check only pre releases even if they dont are the most recent version available.
